### PR TITLE
Add Simple Embeds plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2354,5 +2354,13 @@
         "description": "Move completed tasks to an archive with a date tree",
         "author": "ivan-lednev",
         "repo": "ivan-lednev/obsidian-task-archiver"
+    },
+    {
+        "id": "simple-embeds",
+        "name": "Simple Embeds",
+        "description": "Replace Twitter and YouTube links with embeds when previewing a file.",
+        "author": "Sam Warnick",
+        "repo": "samwarnick/obsidian-simple-embeds",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/samwarnick/obsidian-simple-embeds

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
